### PR TITLE
Allow adding passt, option to disable podman socket

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 ARG FLATCAR_VERSION=3227.2.2
+ARG INCLUDE_PASST=false
+ARG DISABLE_PODMAN_SOCKET=false
 
 FROM mediadepot/flatcar-developer:${FLATCAR_VERSION} AS base
 
@@ -12,6 +14,8 @@ COPY overlay /var/lib/portage/podman-overlay/
 FROM base AS builder
 RUN emerge -j4 --getbinpkg --autounmask-write --autounmask-continue --onlydeps podman
 RUN emerge -j4 --getbinpkg --buildpkgonly podman squashfs-tools
+RUN git clone https://passt.top/passt /root/passt
+RUN cd /root/passt && make
 
 FROM base AS staging
 COPY --from=builder /var/lib/portage/pkgs /var/lib/portage/pkgs
@@ -23,6 +27,9 @@ RUN mkdir -p /work/usr/lib/extension-release.d && echo -e 'ID=flatcar\nSYSEXT_LE
 RUN mkdir -p /work/usr/src
 RUN mv /work/etc /work/usr/etc
 COPY usr /work/usr
+COPY --from=builder /root/passt /work/passt
+RUN if $INCLUDE_PASST; then cd /work/passt && make install DESTDIR=/work; fi; rm -rf /work/passt
+RUN if $DISABLE_PODMAN_SOCKET; then rm -f /work/usr/lib/systemd/system/podman.socket; sed -i '/socket/d' /work/usr/lib/systemd/system/podman.service; fi
 RUN mv /work/opt/cni/bin /work/usr/lib/cni
 RUN rm -rf /work/var /work/usr/include /work/usr/lib*/cmake /work/opt/cni
 RUN rmdir /work/opt

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,15 @@
 TAG = dev:latest
 FLATCAR_VERSION = 3510.2.4
 OVERLAY_DIR = /var/lib/portage/podman-overlay
+INCLUDE_PASST?=false
+DISABLE_PODMAN_SOCKET?=false
 
 podman.raw: container
-	docker run --rm -v $(PWD):/out $(TAG)
+	docker run --rm -v $(CURDIR):/out $(TAG)
 
 .PHONY: container
 container:
-	docker build -t $(TAG) --build-arg FLATCAR_VERSION=$(FLATCAR_VERSION) $(TARGET) .
+	docker build -t $(TAG) --build-arg FLATCAR_VERSION=$(FLATCAR_VERSION) --build-arg DISABLE_PODMAN_SOCKET=$(DISABLE_PODMAN_SOCKET) --build-arg INCLUDE_PASST=$(INCLUDE_PASST) $(TARGET) .
 
 
 base: TARGET=--target base


### PR DESCRIPTION
This adds an option to the Makefile and argument to the docker file that allows adding the passt pasta networking stack, to provide more efficient, yet nonetheless secure user mode networking. This is entirely optional and configurable, as well as disabled by default.

The ability to remove the socket allows for more flexibility in configuring `podman.service`, as apparently you cannot mask sockets properly.